### PR TITLE
Use Hex instead of ASCII

### DIFF
--- a/names.go
+++ b/names.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/rpcclient"
-
 	"github.com/namecoin/ncbtcjson"
 )
 
@@ -70,9 +69,12 @@ func (r FutureNameShowResult) Receive() (*ncbtcjson.NameShowResult, error) {
 //
 // See NameShow for the blocking version and more details.
 func (c *Client) NameShowAsync(name string, options *ncbtcjson.NameShowOptions) FutureNameShowResult {
-	if options != nil && options.NameEncoding == ncbtcjson.Hex {
-		name = hex.EncodeToString([]byte(name))
+	if options == nil {
+		options = &ncbtcjson.NameShowOptions{}
 	}
+
+	options.NameEncoding, options.ValueEncoding = ncbtcjson.Hex, ncbtcjson.Hex
+	name = hex.EncodeToString([]byte(name))
 
 	cmd := ncbtcjson.NewNameShowCmd(name, options)
 


### PR DESCRIPTION
This will allow us to parse CBOR and face fewer bugs.
* It appears that Electrum-NMC has a bug when handling options arguments, as it passes them in the name_encoding field instead of the options field. 
* A simple temporary fix I used is: 
``` 
if type(name_encoding) is dict:
   options = name_encoding
```
[here](https://github.com/namecoin/electrum-nmc/blob/master/electrum_nmc/electrum/commands.py#L1430-L1435)

Fixes https://github.com/namecoin/ncrpcclient/issues/2


